### PR TITLE
Override updates

### DIFF
--- a/stubs/overrides.php
+++ b/stubs/overrides.php
@@ -112,7 +112,7 @@ function get_option( string $option, $default = null ) {}
 /**
  *
  * @param string $path
- * @param "https"|"http" $scheme
+ * @param "https"|"http"|"relative"|"rest" $scheme
  * @return string
  */
 function home_url( string $path = null, $scheme = null ) : string {

--- a/stubs/overrides.php
+++ b/stubs/overrides.php
@@ -7,9 +7,10 @@ class WP_CLI {
 	 *
 	 * @param string $command
 	 * @param callable|class-string $class
+	 * @param array{before_invoke?: callable, after_invoke?: callable, shortdesc?: string, longdesc?: string, synopsis?: string, when?: string, is_deferred?: bool} $args
 	 * @return void
 	 */
-	static function add_command( string $command, $class ) {
+	static function add_command( string $command, $class, array $args = [] ) {
 
 	}
 


### PR DESCRIPTION
Updates `WP_CLI::add_command()` to include third param, `$args`.

Updates `home_url()` to allow `'relative'` or `'rest'` as possible values for `$scheme`.

Addresses #13 and #14.