### PR TITLE
Add support to detect if add_filter was used instead of add_action

### DIFF
--- a/test.php
+++ b/test.php
@@ -15,3 +15,7 @@ function filter_upload_dir( array $dir ) : array {
 add_filter( 'foo', function ( bool $post ) : void {
 	new WP_Post( new StdClass );
 }, 10, 2 );
+
+add_filter( 'admin_notices', function () {
+	echo 'hi';
+} );

--- a/tests/unit/FiltersTest.php
+++ b/tests/unit/FiltersTest.php
@@ -90,6 +90,17 @@ class FiltersTest extends BaseTestCase {
 				} );
 				EOD,
 				'error_message' => 'InvalidArgument',
+			],
+			'add_filter instead of add_action' => [
+				<<<'EOD'
+				<?php
+				do_action( 'test_action' );
+
+				add_filter( 'test_action', function () {
+					echo 'some stuff';
+				} );
+				EOD,
+				'error_message' => 'HookNotFound',
 			]
 		];
 	}


### PR DESCRIPTION
Fixes a Error which caused psalm to crash if code like:
```php
add_filter( 'admin_notices', function () {
	echo 'hi';
} );
```
is encountered. `admin_notices` is really an action but WordPress does not care and triggers the hook just the same. I believe flagging it as a problem is the best action. Much better than crashing like:
```
Uncaught RuntimeException: PHP Error: Undefined offset: 0 in .../vendor/humanmade/psalm-plugin-wordpress/Plugin.php:278 in .../vendor/vimeo/psalm/src/Psalm/Internal/ErrorHandler.php:66
```
