### PR TITLE
do not load the stubs provided by this plugin but use the psalm native ones

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -39,7 +39,12 @@ class Plugin implements PluginEntryPointInterface, AfterEveryFunctionCallAnalysi
 
 	public function __invoke( RegistrationInterface $registration, ?SimpleXMLElement $config = null ) : void {
 		$registration->registerHooksFromClass( static::class );
-		array_map( [ $registration, 'addStubFile' ], $this->getStubFiles() );
+
+		// if useDefaultStubs is not set or set to anything except false, we want to load the stubs included in this plugin
+		if ( !isset( $config->useDefaultStubs['value'] ) || (string) $config->useDefaultStubs['value'] !== 'false' ) {
+			array_map( [ $registration, 'addStubFile' ], $this->getStubFiles() );
+		}
+
 		static::loadStubbedHooks();
 	}
 


### PR DESCRIPTION
Fixes https://github.com/humanmade/psalm-plugin-wordpress/issues/20

Change your psalm config to:

```
<plugins>
	<pluginClass class="PsalmWordPress\Plugin">
		<useDefaultStubs value="false" />
	</pluginClass>
</plugins>
```

to not use the stubs provided by this psalm plugin, but use your own supplied via `<stubs>` in psalm config.