### PR TITLE
fix @psalm-suppress comments not working

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -294,7 +294,8 @@ class Plugin implements PluginEntryPointInterface, AfterEveryFunctionCallAnalysi
 					new HookNotFound(
 						'Hook ' . $hook_name . ' not found',
 						$code_location
-					)
+					),
+					$statements_source->getSuppressedIssues()
 				);
 			}
 			return [];
@@ -307,7 +308,8 @@ class Plugin implements PluginEntryPointInterface, AfterEveryFunctionCallAnalysi
 					new HookNotFound(
 						'Hook ' . $hook_name . ' is a filter not an action',
 						$code_location
-					)
+					),
+					$statements_source->getSuppressedIssues()
 				);
 			}
 			return [];
@@ -320,7 +322,8 @@ class Plugin implements PluginEntryPointInterface, AfterEveryFunctionCallAnalysi
 					new HookNotFound(
 						'Hook ' . $hook_name . ' is an action not a filter',
 						$code_location
-					)
+					),
+					$statements_source->getSuppressedIssues()
 				);
 			}
 			return [];


### PR DESCRIPTION
for HookNotFound error

```
/**
 * e.g. this hook is defined in wp_schedule_single_event call, which are not parsed by wp-hooks-generator (yet)
 *
 * @psalm-suppress HookNotFound
 */
add_action( 'foo', 'bar' );
```