### PR TITLE
Fix return type for WP_CLI::add_command() override

### DIFF
--- a/stubs/overrides.php
+++ b/stubs/overrides.php
@@ -8,7 +8,7 @@ class WP_CLI {
 	 * @param string $command
 	 * @param callable|class-string $class
 	 * @param array{before_invoke?: callable, after_invoke?: callable, shortdesc?: string, longdesc?: string, synopsis?: string, when?: string, is_deferred?: bool} $args
-	 * @return void
+	 * @return bool
 	 */
 	static function add_command( string $command, $class, array $args = [] ) {
 


### PR DESCRIPTION
WP_CLI::add_command() returns true for a successful addition, false for a deferred addition.

https://github.com/wp-cli/wp-cli/blob/4b446e100398c5774bf2a244f69465ccd65deaa8/php/class-wp-cli.php#L479