### PR TITLE
Update wp hooks dependency renamed wp 6.0 and aliases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.json text eol=lf

--- a/Plugin.php
+++ b/Plugin.php
@@ -115,7 +115,7 @@ class Plugin implements
 			return;
 		}
 
-		$wp_hooks_data_dir = self::getVendorDir( 'vendor/johnbillion/wp-hooks/hooks' );
+		$wp_hooks_data_dir = self::getVendorDir('vendor/wp-hooks/wordpress-core/hooks');
 
 		static::loadHooksFromFile( $wp_hooks_data_dir . '/actions.json' );
 		static::loadHooksFromFile( $wp_hooks_data_dir . '/filters.json' );

--- a/Plugin.php
+++ b/Plugin.php
@@ -184,7 +184,7 @@ class Plugin implements
 
 			static::registerHook( $hook['name'], $parsed_types, $hook['type'] );
 
-			if ( isset( $hook['aliases'] ) ) {
+			if ( isset( $hook['aliases'] ) && is_array( $hook['aliases'] ) ) {
 				foreach ( $hook['aliases'] as $alias_name ) {
 					static::registerHook( $alias_name, $parsed_types, $hook['type'] );
 				}

--- a/Plugin.php
+++ b/Plugin.php
@@ -183,6 +183,12 @@ class Plugin implements
 			}
 
 			static::registerHook( $hook['name'], $parsed_types, $hook['type'] );
+
+			if ( isset( $hook['aliases'] ) ) {
+				foreach ( $hook['aliases'] as $alias_name ) {
+					static::registerHook( $alias_name, $parsed_types, $hook['type'] );
+				}
+			}
 		}
 	}
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -175,7 +175,14 @@ class Plugin implements
 			// Must be done before parseString to avoid notice there.
 			$types = array_filter( $types );
 
-			static::registerHook( $hook['name'], array_map( [ Type::class, 'parseString' ], $types ), $hook['type'] );
+			// skip invalid ones
+			try {
+				$parsed_types = array_map( [ Type::class, 'parseString' ], $types );
+			} catch ( \Psalm\Exception\TypeParseTreeException $e ) {
+				continue;
+			}
+
+			static::registerHook( $hook['name'], $parsed_types, $hook['type'] );
 		}
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
 	],
 	"require": {
 		"ext-simplexml": "*",
-		"wp-hooks/wordpress-core": "^1.2.0",
+		"wp-hooks/wordpress-core": "^1.3.0",
 		"php-stubs/wordpress-stubs": "^6.0",
 		"php-stubs/wordpress-globals": "^0.2.0",
-		"php-stubs/wp-cli-stubs": "^2.5",
+		"php-stubs/wp-cli-stubs": "^2.7",
 		"vimeo/psalm": "^4"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
 	],
 	"require": {
 		"ext-simplexml": "*",
-		"johnbillion/wp-hooks": "^0.8.0",
-		"php-stubs/wordpress-stubs": "^5.5",
+		"wp-hooks/wordpress-core": "^1.2.0",
+		"php-stubs/wordpress-stubs": "^6.0",
 		"php-stubs/wordpress-globals": "^0.2.0",
 		"php-stubs/wp-cli-stubs": "^2.5",
 		"vimeo/psalm": "^4"


### PR DESCRIPTION
This also partially adds the dynamic hook checks requested in https://github.com/humanmade/psalm-plugin-wordpress/issues/12

It's possible to infer all dynamic hooks easily, but this requires a bit more changes I can only PR once my other PRs are merged to avoid having to rebase my PR and fixing tons of conflicts