### PR TITLE
Also allow class constants in hook names

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -489,7 +489,7 @@ class Plugin implements
 
 		// isn't actually supported by the wp-hooks-generator yet and will be handled as regular string there
 		// just handle it generically here for the time being
-		if ( $arg instanceof PhpParser\Node\Expr\ConstFetch ) {
+		if ( $arg instanceof PhpParser\Node\Expr\ConstFetch || $arg instanceof PhpParser\Node\Expr\ClassConstFetch ) {
 			return '{$variable}';
 		}
 


### PR DESCRIPTION
Further fixes for #51.

This avoids crashing on code that does like `apply_filters( self::FILTER_NAME, $value )` (versus `apply_filters( FILTER_NAME, $value )` which was fixed by c69cd0b9).