### PR TITLE
Catch more "There should be a node type provider" exceptions

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -619,7 +619,11 @@ class Plugin implements
 
 		if ( ! $call_args[0]->value instanceof String_ ) {
 			$statements_source = $event->getStatementsSource();
-			$union = $statements_source->getNodeTypeProvider()->getType( $call_args[0]->value );
+			try {
+				$union = $statements_source->getNodeTypeProvider()->getType( $call_args[0]->value );
+			} catch (UnexpectedValueException $e) {
+				$union = null;
+			}
 			if ( ! $union ) {
 				$union = static::getTypeFromArg( $call_args[0]->value, $event->getContext(), $statements_source );
 			}
@@ -821,7 +825,11 @@ class Plugin implements
 		}
 
 		if ( ! $call_args[0]->value instanceof String_ ) {
-			$union = $statements_source->getNodeTypeProvider()->getType( $call_args[0]->value );
+			try {
+				$union = $statements_source->getNodeTypeProvider()->getType( $call_args[0]->value );
+			} catch (UnexpectedValueException $e) {
+				$union = null;
+			}
 			if ( ! $union ) {
 				$union = static::getTypeFromArg( $call_args[0]->value, $event->getContext(), $statements_source );
 			}
@@ -1112,7 +1120,11 @@ class Plugin implements
 		// only apply_filters left to handle
 		if ( ! $call_args[0]->value instanceof String_ ) {
 			$statements_source = $event->getStatementsSource();
-			$union = $statements_source->getNodeTypeProvider()->getType( $call_args[0]->value );
+			try {
+				$union = $statements_source->getNodeTypeProvider()->getType( $call_args[0]->value );
+			} catch (UnexpectedValueException $e) {
+				$union = null;
+			}
 			if ( ! $union ) {
 				$union = static::getTypeFromArg( $call_args[0]->value, $event->getContext(), $statements_source );
 			}


### PR DESCRIPTION
In #47 a try-catch was added to handle one case where `->getStatementsSource()->getNodeTypeProvider()` is being called and is throwing an exception because Psalm's FileAnalyzer doesn't populate the node type provider until after its NamespaceAnalyzer has already tried to analyze the whole file (see also #34).

There are three other code paths making a similar call, at least one of which runs into the same problem. Let's add try-catches to all of them.